### PR TITLE
chore: add clean branch script

### DIFF
--- a/scripts/clean_branch.py
+++ b/scripts/clean_branch.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from huggingface_hub import HfApi
+import time
+
+# ==== Configuration ====
+
+REPO_ID = ""   # Your HF repo, for example: cortexso/qwen3
+BRANCH = ""                         # Branch to clean, for example: 14b
+FILES_TO_KEEP = [                     # Files to keep (exact match, at root)
+    ".gitattributes",
+    "metadata.yml",
+    "model.gguf",
+    "model.yml"
+]
+
+# ========================
+
+def clean_branch_via_api(repo_id: str, branch: str, files_to_keep: list):
+    api = HfApi()
+
+    print(f"\nListing files in branch '{branch}' of repo '{repo_id}'...")
+    all_files = api.list_repo_files(repo_id=repo_id, revision=branch)
+    print(f"✓ Found {len(all_files)} files")
+
+    # Delete all files not in the keep list
+    for file in all_files:
+        if file not in files_to_keep:
+            print(f"Deleting: {file}")
+            try:
+                api.delete_file(
+                    path_in_repo=file,
+                    repo_id=repo_id,
+                    repo_type="model",
+                    revision=branch,
+                )
+                time.sleep(0.5)  # small delay to avoid rate limiting
+            except Exception as e:
+                print(f"✗ Failed to delete {file}: {e}")
+    
+    print(f"\n✓ Cleanup complete for branch '{branch}'.")
+
+if __name__ == "__main__":
+    clean_branch_via_api(REPO_ID, BRANCH, FILES_TO_KEEP)


### PR DESCRIPTION
This pull request introduces a new script, `clean_branch.py`, designed to automate the cleanup of specific branches in Hugging Face repositories by removing files not listed in a predefined "keep" list.

### New functionality:

* [`scripts/clean_branch.py`](diffhunk://#diff-7b6ee6cea7417b90b13b81584d50280c62157101ecde1153500be319b7041130R1-R43): Added a Python script that uses the Hugging Face Hub API to clean up a specified branch in a repository. The script retains only the files listed in the `FILES_TO_KEEP` configuration, deletes all others, and includes error handling and rate-limiting safeguards.